### PR TITLE
Clean up button theme

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -185,7 +185,7 @@ const customConfig = defineConfig({
             outline: {
               borderWidth: "2px",
               borderColor: "colorPalette.solid",
-              color: "fg" ,
+              color: "colorPalette.fg" ,
               bg: "transparent",
               _hover: {
                 bg: "colorPalette.fg/30",
@@ -194,7 +194,7 @@ const customConfig = defineConfig({
             ghost: {
               borderWidth: "0px", 
               bg: "transparent", 
-              color: "fg",
+              color: "colorPalette.fg",
               _hover: {
                 color: "colorPalette.solid",
               },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -169,41 +169,36 @@ const customConfig = defineConfig({
         },
         variants: {
           variant: {
-            solid: { 
+            solid: {
               borderWidth: "2px", 
               borderColor: "colorPalette.solid", 
-              bg: "colorPalette.solid", 
-              color: "colorPalette.contrast",
               _hover: {
-                  bg: "colorPalette.muted",
-                  borderColor: "colorPalette.muted", 
-                  color: "whiteText",
-                },
+                bg: "colorPalette.muted",
+                borderColor: "colorPalette.muted",
+                color: "whiteText",
+              },
               _expanded: {
-                  bg: "colorPalette.muted",
-                  borderColor: "colorPalette.muted", 
-                },
-             },
+                bg: "colorPalette.muted",
+                borderColor: "colorPalette.muted",
+              },
+            },
             outline: {
-               borderWidth: "2px", 
-               borderColor: "colorPalette.solid", 
-               color: "fg.DEFAULT" ,
-               bg: "transparent",
-               _hover: {
-                  bg: "colorPalette.fg/30",
-                },},
-            ghost: { 
+              borderWidth: "2px",
+              borderColor: "colorPalette.solid",
+              color: "fg" ,
+              bg: "transparent",
+              _hover: {
+                bg: "colorPalette.fg/30",
+              },
+            },
+            ghost: {
               borderWidth: "0px", 
               bg: "transparent", 
-              color: "fg.DEFAULT",
+              color: "fg",
               _hover: {
-                  color: "colorPalette.solid", 
-                  bg: "transparent", 
-                },
-                _expanded: {
-                  bg: "transparent",
-                },
-                 },
+                color: "colorPalette.solid",
+              },
+            },
             surface: {
               color: "whiteText",
             },
@@ -218,7 +213,6 @@ const customConfig = defineConfig({
           size: {
             sm: {
               padding: "3",
-              textStyle: "sm",
             },
             lg: {
               px: "6",


### PR DESCRIPTION
- Linting (especially indentation)
- A handful of rules were redundant (they were setting the exact same values that the Chakra default was already set to)
- Instead of hard-coding `fg`, use `colorPalette.fg`