### PR TITLE
Use 'For' Chakra component to loop component props in styleguide

### DIFF
--- a/src/app/information/styleguide/page.tsx
+++ b/src/app/information/styleguide/page.tsx
@@ -1,38 +1,38 @@
 import * as React from 'react';
-import {Button, Center, Heading, Flex, Stack, Text, For} from "@chakra-ui/react";
+import {Button, Heading, Text, For, HStack, Container, VStack} from "@chakra-ui/react";
 
 const buttonVariants = ['solid', 'ghost', 'outline', 'plain', 'subtle'];
 const wcaColors = ["wcablue", "wcagreen", "wcared", "wcaorange", "wcayellow"];
 
 export default function Home() {
   return (
-    <Center>
-      <Stack maxW="2xl">
-        {/* Page Title */}
-        <Heading>
-          STYLE GUIDE
-        </Heading>
+    <Container maxWidth="2xl">
+      {/* Page Title */}
+      <Heading>
+        STYLE GUIDE
+      </Heading>
+      <VStack>
         <For each={buttonVariants}>
           {(buttonVariant, index) => (
-              <React.Fragment key={`button-variant-${index}`}>
-                <Text>Buttons: {buttonVariant}</Text>
-                <Flex gap="2">
-                  <For each={wcaColors} >
-                    {(wcaColor, index) => (
-                      <Button
-                        key={`button-variant-${buttonVariant}-${index}`}
-                        variant={buttonVariant}
-                        colorPalette={wcaColor}
-                      >
-                        {wcaColor.replace("wca", "").toLowerCase()}
-                      </Button>
-                    )}
-                  </For>
-                </Flex>
-              </React.Fragment>
+            <React.Fragment key={`button-variant-${index}`}>
+              <Text>Buttons: {buttonVariant}</Text>
+              <HStack justify="space-between">
+                <For each={wcaColors} >
+                  {(wcaColor, index) => (
+                    <Button
+                      key={`button-variant-${buttonVariant}-${index}`}
+                      variant={buttonVariant}
+                      colorPalette={wcaColor}
+                    >
+                      {wcaColor.replace("wca", "").toLowerCase()}
+                    </Button>
+                  )}
+                </For>
+              </HStack>
+            </React.Fragment>
           )}
         </For>
-      </Stack>
-    </Center>
+      </VStack>
+    </Container>
     );
 }

--- a/src/app/information/styleguide/page.tsx
+++ b/src/app/information/styleguide/page.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import {Button, Center, Heading, Flex, Stack, Text} from "@chakra-ui/react";
+import {Button, Center, Heading, Flex, Stack, Text, For} from "@chakra-ui/react";
+
+const buttonVariants = ['solid', 'ghost', 'outline', 'plain', 'subtle'];
+const wcaColors = ["wcablue", "wcagreen", "wcared", "wcaorange", "wcayellow"];
 
 export default function Home() {
   return (
@@ -9,52 +12,27 @@ export default function Home() {
         <Heading>
           STYLE GUIDE
         </Heading>
-        <Text>Solid Buttons</Text>
-        <Flex gap="2">
-            <Button>Default Button</Button> 
-            <Button colorPalette="wcagreen">Green Button</Button> 
-            <Button colorPalette="wcared">Red Button</Button> 
-            <Button colorPalette="wcaorange">Orange Button</Button> 
-            <Button colorPalette="wcayellow">Yellow Button</Button> 
-        </Flex>
-
-        <Text>Ghost Buttons</Text>
-        <Flex gap="2">
-            <Button variant="ghost">Default Button</Button> 
-            <Button colorPalette="wcagreen" variant="ghost">Green Button</Button> 
-            <Button colorPalette="wcared" variant="ghost">Red Button</Button> 
-            <Button colorPalette="wcaorange" variant="ghost">Orange Button</Button> 
-            <Button colorPalette="wcayellow" variant="ghost">Yellow Button</Button> 
-        </Flex>
-
-        <Text>Outline Buttons</Text>
-        <Flex gap="2">
-            <Button variant="outline">Default Button</Button> 
-            <Button colorPalette="wcagreen" variant="outline">Green Button</Button> 
-            <Button colorPalette="wcared" variant="outline">Red Button</Button> 
-            <Button colorPalette="wcaorange" variant="outline">Orange Button</Button> 
-            <Button colorPalette="wcayellow" variant="outline">Yellow Button</Button> 
-        </Flex>
-
-        <Text>Plain Buttons</Text>
-        <Flex gap="2">
-            <Button variant="plain">Default Button</Button> 
-            <Button colorPalette="wcagreen" variant="plain">Green Button</Button> 
-            <Button colorPalette="wcared" variant="plain">Red Button</Button> 
-            <Button colorPalette="wcaorange" variant="plain">Orange Button</Button> 
-            <Button colorPalette="wcayellow" variant="plain">Yellow Button</Button> 
-        </Flex>
-
-
-        <Text>Subtle Buttons</Text>
-        <Flex gap="2">
-            <Button variant="subtle">Default Button</Button> 
-            <Button colorPalette="wcagreen" variant="subtle">Green Button</Button> 
-            <Button colorPalette="wcared" variant="subtle">Red Button</Button> 
-            <Button colorPalette="wcaorange" variant="subtle">Orange Button</Button> 
-            <Button colorPalette="wcayellow" variant="subtle">Yellow Button</Button> 
-        </Flex>
-        </Stack>
+        <For each={buttonVariants}>
+          {(buttonVariant, index) => (
+              <React.Fragment key={`button-variant-${index}`}>
+                <Text>Buttons: {buttonVariant}</Text>
+                <Flex gap="2">
+                  <For each={wcaColors} >
+                    {(wcaColor, index) => (
+                      <Button
+                        key={`button-variant-${buttonVariant}-${index}`}
+                        variant={buttonVariant}
+                        colorPalette={wcaColor}
+                      >
+                        {wcaColor.replace("wca", "").toLowerCase()}
+                      </Button>
+                    )}
+                  </For>
+                </Flex>
+              </React.Fragment>
+          )}
+        </For>
+      </Stack>
     </Center>
     );
 }


### PR DESCRIPTION
Only disadvantage: You lose a bit of flexibility about the button contents. But some `uppercaseFirst` shenanigans should allow you to exactly reproduce the previous status quo.

![image](https://github.com/user-attachments/assets/7f57e09f-18bb-4bde-8f9f-b4412d89c51d)
