### PR TITLE
Added Heading Styles from Brand Guide

### DIFF
--- a/src/app/information/styleguide/page.tsx
+++ b/src/app/information/styleguide/page.tsx
@@ -32,6 +32,14 @@ export default function Home() {
             </React.Fragment>
           )}
         </For>
+        <VStack gap="2" align="flex-start">
+            <Heading size="md">Subheading (S2) - "md"</Heading>
+            <Heading size="lg">Subheading (S1) - "lg"</Heading>
+            <Heading size="2xl">Heading (H4) - "2xl"</Heading>
+            <Heading size="3xl">Heading (H3) - "3xl"</Heading>
+            <Heading size="4xl">Heading (H2) - "4xl"</Heading>
+            <Heading size="5xl">Heading (H1) - "5xl"</Heading>
+        </VStack>
       </VStack>
     </Container>
     );

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -301,9 +301,47 @@ const customConfig = defineConfig({
           variant: "solid",
           size: "lg",
         },
-      }
-    }
+      },
+      heading: {
+        base: {
 
+        },
+        variants: {
+          size: {
+            sm: {
+              fontWeight: "medium",//Not used in styleguide
+            },
+            md: {
+              fontWeight: "medium",//Subheading 2
+              textStyle: "lg",//same size as lg, just thinner
+            },
+            lg: {
+              fontWeight: "bold",//Subheading 1
+            },
+            xl: {
+              fontWeight: "bold",//Not used in styleguide
+            },
+            "2xl": {
+              fontWeight: "extrabold",//H4
+            },
+            "3xl": {
+              fontWeight: "extrabold",//H3
+            },
+            "4xl": {
+              fontWeight: "extrabold",//H2
+            },
+            "5xl": {
+              fontWeight: "extrabold",//H1
+              textTransform: "uppercase"
+            },
+            "6xl": {
+              fontWeight: "extrabold",//Not used in styleguide
+            }
+          }
+        }
+      },
+      
+    },
   },
 });
 


### PR DESCRIPTION
- Modified font weights of existing Chakra heading styles to align with the WCA Brand guide. (Notice that H4 was added as an extra option for future WCA developers to use if they see fit)
- Made both the "md" and "lg" semantic tokens use the "lg" sizing, as the difference between these two subheadings is just the font weight.
- Added all Heading sizes that should be used to the styleguide page under information/styleguide

See Below Photo from the information/styleguide page:
![image](https://github.com/user-attachments/assets/1a7db2e0-5100-4bdc-bb6f-60620f1cc7c6)


See Below Photo from the WCA Brand Guide:
![image](https://github.com/user-attachments/assets/dd8b4130-4c4a-42b2-b33e-c513f3e0806c)
