### PR TITLE
Hero profile cards Added into styleguide

### DIFF
--- a/src/app/information/styleguide/page.tsx
+++ b/src/app/information/styleguide/page.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import {Button, Heading, Text, For, HStack, Container, VStack} from "@chakra-ui/react";
+import {Button, Heading, Text, For, HStack, Container, VStack, Flex, Card, Image} from "@chakra-ui/react";
 
 const buttonVariants = ['solid', 'ghost', 'outline', 'plain', 'subtle'];
 const wcaColors = ["blue", "green", "red", "orange", "yellow"];
 
 export default function Home() {
   return (
-    <Container maxWidth="2xl">
+    <Container maxWidth="breakpoint-lg">
       {/* Page Title */}
       <Heading>
         STYLE GUIDE
@@ -32,6 +32,7 @@ export default function Home() {
             </React.Fragment>
           )}
         </For>
+        <Text>Heading Styles</Text>
         <VStack gap="2" align="flex-start">
             <Heading size="md">Subheading (S2) - "md"</Heading>
             <Heading size="lg">Subheading (S1) - "lg"</Heading>
@@ -40,6 +41,67 @@ export default function Home() {
             <Heading size="4xl">Heading (H2) - "4xl"</Heading>
             <Heading size="5xl">Heading (H1) - "5xl"</Heading>
         </VStack>
+
+        <Text >Hero Profile Info</Text>
+        <Flex gap="2">
+            <Card.Root maxW="sm" overflow="hidden" variant="elevated" colorPalette="green">
+                <Image
+                    src="https://avatars.worldcubeassociation.org/uploads/user/avatar/2014PRID01/1651581622.PNG"
+                    alt="Ethan Pride Profile Photo"
+                    aspectRatio="landscape"
+                />
+                <Card.Body gap="2">
+                    <Heading size="2xl" textTransform="uppercase">Ethan Pride</Heading>
+                    <Flex align="center" gap="1.5">
+                        <Image 
+                        src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f1e6-1f1fa.svg"
+                        alt="AUS Flag"
+                        height="1.2rem"
+                        />
+                        <Text textStyle="sm" fontWeight="medium">Australia</Text>
+                    </Flex>
+                </Card.Body>
+            </Card.Root>
+
+            <Card.Root maxW="sm" overflow="hidden" variant="elevated" colorPalette="blue">
+                <Image
+                    src="https://avatars.worldcubeassociation.org/uploads/user/avatar/2019JARM01/1686450645.jpg"
+                    alt="Kerri Jarman Profile Photo"
+                    aspectRatio="landscape"
+                />
+                <Card.Body gap="2">
+                    <Heading size="2xl" textTransform="uppercase">Kerrie Jarman</Heading>
+                    <Flex align="center" gap="1.5">
+                        <Image 
+                        src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f1e6-1f1fa.svg"
+                        alt="AUS Flag"
+                        height="1.2rem"
+                        />
+                        <Text textStyle="sm" fontWeight="medium">Australia</Text>
+                    </Flex>
+                </Card.Body>
+            </Card.Root>
+
+            <Card.Root maxW="sm" overflow="hidden" variant="elevated" colorPalette="yellow">
+                <Image
+                    src="https://avatars.worldcubeassociation.org/uploads/user/avatar/2016SILV08/1713202675.jpg"
+                    alt="Nick Silvestri Profile Photo"
+                    aspectRatio="landscape"
+                />
+                <Card.Body gap="2">
+                    <Heading size="2xl" textTransform="uppercase">Nick Silvestri</Heading>
+                    <Flex align="center" gap="1.5">
+                        <Image 
+                        src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f1fa-1f1f8.svg"
+                        alt="USA Flag"
+                        height="1.2rem"
+                        />
+                        <Text textStyle="sm" fontWeight="medium">United States</Text>
+                    </Flex>
+                </Card.Body>
+            </Card.Root>
+        </Flex>
+
       </VStack>
     </Container>
     );

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -342,6 +342,17 @@ const customConfig = defineConfig({
       },
       
     },
+    slotRecipes: {
+      card: {
+        slots: ["root", "header", "body", "footer", "title", "description"],
+        base: {
+          body: {
+            bg: "colorPalette.solid",
+            color:  "colorPalette.contrast",
+          }
+        }
+      },
+    },
   },
 });
 


### PR DESCRIPTION
- Added fucntionality for a solid colour background card - just add a colour Palette to any Card.Root now.
- Created 3 Sample cards (As seen Below)
![image](https://github.com/user-attachments/assets/067c0906-7ea4-4722-b3e0-2bcc119b914e)

- Also widened the styleguide page to accommodate more than one or two cards comfortably