### PR TITLE
Add background icons to MedalSummaryCard and RecordSummaryCard

### DIFF
--- a/src/components/MedalSummaryCard.tsx
+++ b/src/components/MedalSummaryCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Stat, Card, StatGroup} from "@chakra-ui/react";
+import {Stat, Card, StatGroup, Float, Icon} from "@chakra-ui/react";
+import {LuMedal} from "react-icons/lu";
 
 interface MedalSummaryCardProps {
   gold: number;
@@ -9,7 +10,12 @@ interface MedalSummaryCardProps {
 
 const MedalSummaryCard: React.FC<MedalSummaryCardProps> = ({ gold, silver, bronze }) => {
   return (
-    <Card.Root bg="wcayellow.solid" color="wcayellow.contrast" shadow="wca">
+    <Card.Root colorPalette="yellow" variant="hero" overflow="hidden">
+      <Float placement="middle-end" offsetX="8">
+        <Icon fontSize="10rem" color="colorPalette.400">
+          <LuMedal />
+        </Icon>
+      </Float>
       <Card.Body>
         <Card.Title>Medal Collection</Card.Title>
         <StatGroup size="lg">

--- a/src/components/RecordSummaryCard.tsx
+++ b/src/components/RecordSummaryCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Card } from "@chakra-ui/react";
-import { Stat, StatGroup } from "@chakra-ui/react";
+import {Card, Float, Icon, Stat, StatGroup} from "@chakra-ui/react";
+import {LuAward} from "react-icons/lu";
 
 interface RecordSummaryCardProps {
   world: number;
@@ -10,7 +10,12 @@ interface RecordSummaryCardProps {
 
 const RecordSummaryCard: React.FC<RecordSummaryCardProps> = ({ world, continental, national }) => {
   return (
-    <Card.Root bg="wcagreen.solid" color="wcagreen.contrast" shadow="wca">
+    <Card.Root colorPalette="green" variant="hero" overflow="hidden">
+      <Float placement="middle-end" offsetX="8">
+        <Icon fontSize="10rem" color="colorPalette.400">
+          <LuAward />
+        </Icon>
+      </Float>
       <Card.Body>
         <Card.Title>Record Collection</Card.Title>
         <StatGroup size="lg">


### PR DESCRIPTION
Using the `Float` component, along with `overflow: hidden` to make sure the parts of the icon that are outside of the container disappear.

Color and icon choices tentative.

![image](https://github.com/user-attachments/assets/b29022ba-1385-4c6a-9b9e-a0e1e8162b45)
